### PR TITLE
Disable gpg signing (the build infra does this)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -200,20 +200,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-gpg-plugin</artifactId>
-                 <version>1.6</version>
-                 <executions>
-                     <execution>
-                         <id>sign-artifacts</id>
-                         <phase>verify</phase>
-                         <goals>
-                             <goal>sign</goal>
-                         </goals>
-                     </execution>
-                 </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>                           
                 <artifactId>maven-release-plugin</artifactId>                         
                  <version>2.5.2</version>


### PR DESCRIPTION
Remove this as a) it breaks the Jenkins build and b) the release build will do this for us.