### PR TITLE
Copy .gitignore from master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+.classpath
+.project
+.settings


### PR DESCRIPTION
Not having the file on the release branch creates issues for ignored files when moving between branches in my IDE.

Signed-off-by: Mark Thomas <markt@apache.org>