### PR TITLE
[EE4J-8] Removed @Deprecated annotation to fix CTS tests failure.

### DIFF
--- a/api/src/main/java/javax/servlet/jsp/el/ELParseException.java
+++ b/api/src/main/java/javax/servlet/jsp/el/ELParseException.java
@@ -24,7 +24,6 @@ package javax.servlet.jsp.el;
  * @deprecated As of JSP 2.1, replaced by {@link javax.el.ELException}
  * @since JSP 2.0
  */
-@Deprecated
 public class ELParseException extends ELException {
 
     private static final long serialVersionUID = 3521581805886060118L;


### PR DESCRIPTION
EE4J_8 branch only fix.
We can keep master branch as is because next release can introduce such an annotation.