### PR TITLE
Fix #16 Add new omit attribute to EBNF

### DIFF
--- a/spec/src/main/asciidoc/ServerPages.adoc
+++ b/spec/src/main/asciidoc/ServerPages.adoc
@@ -1371,7 +1371,7 @@ PluginBody                 ::=   EmptyBody
 
 NamedAttributes            ::= AttributeBody S? ( '<jsp:attribute' AttributeBody S? )*
 
-AttributeBody              ::=   ATTR[ !name, trim ] S?
+AttributeBody              ::=   ATTR[ !name, trim, omit ] S?
                                (   '/>'
                                  | '></jsp:attribute>'
                                  | '>' AttributeBodyBody '</jsp:attribute>'


### PR DESCRIPTION
'omit' was not added to EBNF at the time it was added to the spec.