### PR TITLE
Clean up and fixes

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,7 +25,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <groupId>jakarta.servlet.jsp</groupId>
@@ -36,31 +36,22 @@
     <name>Jakarta Server Pages API</name>
     <description>Jakarta Server Pages API</description>
     <url>https://projects.eclipse.org/projects/ee4j.jsp</url>
-    <licenses>
-        <license>
-            <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>GPL2 w/ CPE</name>
-            <url>https://www.gnu.org/software/classpath/license.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <developers>
         <developer>
-            <id>yaminikb</id>
-            <name>Yamini K B</name>
-            <organization>Oracle Corporation</organization>
-            <organizationUrl>http://www.oracle.com</organizationUrl>
+            <id>jakarta-ee4j-jsp</id>
+            <name>Jakarta Server Pages Developers</name>
+            <organization>Eclipse Foundation</organization>
+            <email>jsp-dev@eclipse.org</email>
         </developer>
     </developers>
+
     <contributors>
-        <contributor>
-            <name>Kin Man Chung</name>
-        </contributor>
+       <contributor>
+           <name>Jakarta Server Pages Contributors</name>
+           <email>jsp-dev@eclipse.org</email>
+           <url>https://github.com/eclipse-ee4j/jsp-api/graphs/contributors</url>
+       </contributor>
     </contributors>
 
     <mailingLists>
@@ -79,6 +70,7 @@
         <url>https://github.com/eclipse-ee4j/jsp-api</url>
         <tag>HEAD</tag>
     </scm>
+
     <issueManagement>
         <system>github</system>
         <url>https://github.com/eclipse-ee4j/jsp-api/issues</url>
@@ -103,7 +95,7 @@
         <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
-            <version>4.0.0-RC1</version>
+            <version>4.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -125,12 +117,13 @@
                 <targetPath>META-INF</targetPath>
             </resource>
         </resources>
+
         <plugins>
             <!-- Sets minimal Maven version to 3.5.4 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -141,6 +134,7 @@
                             <rules>
                                 <requireMavenVersion>
                                     <version>3.5.4</version>
+                                    <message>You need Maven 3.5.4 or higher</message>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -24,6 +25,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.glassfish.web</groupId>
@@ -33,31 +35,22 @@
     <name>Jakarta Server Pages implementation</name>
     <description>JavaServer Pages API</description>
     <url>https://projects.eclipse.org/projects/ee4j.jsp</url>
-    <licenses>
-        <license>
-            <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>GPL2 w/ CPE</name>
-            <url>https://www.gnu.org/software/classpath/license.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <developers>
         <developer>
-            <id>yaminikb</id>
-            <name>Yamini K B</name>
-            <organization>Oracle Corporation</organization>
-            <organizationUrl>http://www.oracle.com</organizationUrl>
+            <id>jakarta-ee4j-jsp</id>
+            <name>Jakarta Server Pages Developers</name>
+            <organization>Eclipse Foundation</organization>
+            <email>jsp-dev@eclipse.org</email>
         </developer>
     </developers>
+
     <contributors>
-        <contributor>
-            <name>Kin Man Chung</name>
-        </contributor>
+       <contributor>
+           <name>Jakarta Server Pages Contributors</name>
+           <email>jsp-dev@eclipse.org</email>
+           <url>https://github.com/eclipse-ee4j/jsp-api/graphs/contributors</url>
+       </contributor>
     </contributors>
 
     <mailingLists>
@@ -76,12 +69,15 @@
         <url>https://github.com/eclipse-ee4j/jsp-api</url>
         <tag>HEAD</tag>
     </scm>
+
     <issueManagement>
         <system>github</system>
         <url>https://github.com/eclipse-ee4j/jsp-api/issues</url>
     </issueManagement>
 
     <properties>
+        <!-- the bundle build number must be the same as the maven number -->
+        <bundle.version>${project.version}</bundle.version>
         <spec.version>3.0</spec.version>
         <extensionName>jakarta.servlet.jsp</extensionName>
         <bundle.symbolicName>org.glassfish.web.jakarta.servlet.jsp</bundle.symbolicName>
@@ -99,12 +95,12 @@
         <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
-            <version>4.0.0-RC1</version>
+            <version>4.0.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
-            <version>3.0.0-M1</version>
+            <version>${bundle.version}</version>
         </dependency>
 
         <!-- Other dependencies -->
@@ -131,6 +127,14 @@
                 </includes>
             </resource>
             <resource>
+                <directory>${project.basedir}/..</directory>
+                <includes>
+                    <include>LICENSE.md</include>
+                    <include>NOTICE.md</include>
+                </includes>
+                <targetPath>META-INF</targetPath>
+            </resource>
+            <resource>
                 <directory>src/main/resources</directory>
                 <includes>
                     <include>jakarta.servlet.ServletContainerInitializer</include>
@@ -138,12 +142,13 @@
                 <targetPath>META-INF/services</targetPath>
             </resource>
         </resources>
+
         <plugins>
             <!-- Sets minimal Maven version to 3.5.4 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -154,6 +159,7 @@
                             <rules>
                                 <requireMavenVersion>
                                     <version>3.5.4</version>
+                                    <message>You need Maven 3.5.4 or higher</message>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -161,31 +167,9 @@
                 </executions>
             </plugin>
 
-            <!-- Restricts the Java version to 1.8 -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                    <compilerArgument>-Xlint:unchecked</compilerArgument>
-                    <excludes>
-                        <exclude>
-                            org/apache/jasper/compiler/JDTJavaCompiler.java
-                        </exclude>
-                        <exclude>
-                            org/apache/jasper/compiler/AntJavaCompiler.java
-                        </exclude>
-                        <exclude>
-                            <!-- This is only used by AntJavaCompiler -->
-                            org/apache/jasper/util/SystemLogHandler.java
-                        </exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <!-- Creates the OSGi MANIFEST.MF file -->
+            <!-- Configure maven-bundle-plugin to generate OSGi manifest. Please note: we use the manifest goal only and not the bundle goal. 
+                The bundle goal can lead to very surprising results if the package names are not correctly specified. So, we use the jar plugin to generate the 
+                jar. -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -228,22 +212,28 @@
                 </configuration>
             </plugin>
 
-            <!-- Creates the source jar -->
+            <!-- Restricts the Java version to 1.8 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
-                    <includePom>true</includePom>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <compilerArgument>-Xlint:unchecked</compilerArgument>
+                    <excludes>
+                        <exclude>
+                            org/apache/jasper/compiler/JDTJavaCompiler.java
+                        </exclude>
+                        <exclude>
+                            org/apache/jasper/compiler/AntJavaCompiler.java
+                        </exclude>
+                        <exclude>
+                            <!-- This is only used by AntJavaCompiler -->
+                            org/apache/jasper/util/SystemLogHandler.java
+                        </exclude>
+                    </excludes>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
 
             <!-- Create Javadoc for API jar -->
@@ -262,10 +252,16 @@
                             <additionalJOption>-Xdoclint:none</additionalJOption>
                             <groups>
                                 <group>
-                                    <title>Jakarta Server Pages API Documentation</title>
-                                    <packages>jakarta.servlet.jsp</packages>
+                                    <title>Jakarta Server Pages ${spec.version} Implementation</title>
+                                    <packages>org.apache.jasper</packages>
+                                    <packages>glassfish.jsp.api</packages>
                                 </group>
                             </groups>
+                            <bottom><![CDATA[
+Comments to: <a href="mailto:el-dev@eclipse.org">el-dev@eclipse.org</a>.<br>
+Copyright &#169; 2018, 2020 Eclipse Foundation. All rights reserved.<br>
+Use is subject to <a href="http://www.eclipse.org/legal/epl-2.0" target="_top">license terms</a>.]]>
+                            </bottom>
                         </configuration>
                     </execution>
                 </executions>

--- a/impl/src/main/java/org/apache/jasper/EmbeddedServletOptions.java
+++ b/impl/src/main/java/org/apache/jasper/EmbeddedServletOptions.java
@@ -376,7 +376,7 @@ public final class EmbeddedServletOptions implements Options {
     }
 
     /**
-     * @see Options#getCompilerName
+     * @see Options#getCompiler
      */
     public String getCompilerClassName() {
         return compilerClassName;

--- a/impl/src/main/java/org/apache/jasper/JspC.java
+++ b/impl/src/main/java/org/apache/jasper/JspC.java
@@ -664,14 +664,14 @@ public class JspC implements Options {
     }
 
     /**
-     * @see Options#getCompilerSourceVM.
+     * @see Options#getCompilerSourceVM
      */
      public String getCompilerSourceVM() {
          return compilerSourceVM;
      }
         
     /**
-     * @see Options#getCompilerSourceVM.
+     * @see Options#getCompilerSourceVM
      */
     public void setCompilerSourceVM(String vm) {
         // START SJSAS 6402545
@@ -688,7 +688,7 @@ public class JspC implements Options {
     }
 
     /**
-     * @see Options#getCompilerClassName.
+     * @see Options#getCompilerClassName
      */
     public String getCompilerClassName() {
         return null;

--- a/impl/src/main/java/org/apache/jasper/compiler/SmapUtil.java
+++ b/impl/src/main/java/org/apache/jasper/compiler/SmapUtil.java
@@ -63,9 +63,7 @@ public class SmapUtil {
      * Generates an appropriate SMAP representing the current compilation
      * context.  (JSR-045.)
      *
-     * @param ctxt Current compilation context
      * @param pageNodes The current JSP page
-     * @return a SMAP for the page
      */
     public void generateSmap(Node.Nodes pageNodes)
         throws IOException {

--- a/impl/src/main/java/org/apache/jasper/xmlparser/SymbolTable.java
+++ b/impl/src/main/java/org/apache/jasper/xmlparser/SymbolTable.java
@@ -40,11 +40,7 @@ package org.apache.jasper.xmlparser;
  *  </li>
  * </ul>
  *
- * @see SymbolHash
- *
  * @author Andy Clark
- *
- * @version $Id: SymbolTable.java,v 1.2 2005/12/08 01:29:00 kchung Exp $
  */
 public class SymbolTable {
 

--- a/impl/src/main/java/org/apache/jasper/xmlparser/XMLChar.java
+++ b/impl/src/main/java/org/apache/jasper/xmlparser/XMLChar.java
@@ -918,7 +918,7 @@ public class XMLChar {
      * Check to see if a string is a valid NCName according to [4]
      * from the XML Namespaces 1.0 Recommendation
      *
-     * @param name string to check
+     * @param ncName string to check
      * @return true if name is a valid NCName
      */
     public static boolean isValidNCName(String ncName) {

--- a/jdsol-spec/pom.xml
+++ b/jdsol-spec/pom.xml
@@ -31,17 +31,65 @@
     <artifactId>jdsol-spec</artifactId>
     <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <name>Jakarta Debugging Support for Other Languages Specification</name>
     <description>Jakarta Debugging Support for Other Languages - Specification</description>
     <url>https://projects.eclipse.org/projects/ee4j.jsp</url>
 
+    <licenses>
+        <license>
+            <name>Eclipse Foundation Specification License – v1.0</name>
+            <url>https://www.eclipse.org/legal/efsl.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>jakarta-ee4j-jsp</id>
+            <name>Jakarta Server Pages Developers</name>
+            <organization>Eclipse Foundation</organization>
+            <email>jsp-dev@eclipse.org</email>
+        </developer>
+    </developers>
+
+    <contributors>
+       <contributor>
+           <name>Jakarta Server Pages Contributors</name>
+           <email>jsp-dev@eclipse.org</email>
+           <url>https://github.com/eclipse-ee4j/jsp-api/graphs/contributors</url>
+       </contributor>
+    </contributors>
+
+    <mailingLists>
+        <mailingList>
+            <name>JSP dev mailing list</name>
+            <post>jsp-dev@eclipse.org</post>
+            <subscribe>https://dev.eclipse.org/mailman/listinfo/jsp-dev</subscribe>
+            <unsubscribe>https://dev.eclipse.org/mailman/listinfo/jsp-dev</unsubscribe>
+            <archive>https://dev.eclipse.org/mhonarc/lists/jsp-dev</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-ee4j/jsp-api.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/jsp-api.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/jsp-api</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/eclipse-ee4j/jsp-api/issues</url>
+    </issueManagement>
+
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.6.2</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <jruby.version>9.2.6.0</jruby.version>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.2.0</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <jruby.version>9.2.11.1</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -51,6 +99,33 @@
     <build>
         <defaultGoal>package</defaultGoal>
         <plugins>
+            <!-- Sets minimal Maven version to 3.5.4 and Java version to 8 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.4</version>
+                                    <message>You need Maven 3.5.4 or higher</message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                    <message>You need JDK8 or higher</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -70,27 +145,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[1.8.0,)</version>
-                                    <message>You need JDK8 or higher</message>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -176,29 +231,11 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
-                <configuration>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <useReleaseProfile>false</useReleaseProfile>
-                    <arguments>${release.arguments}</arguments>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.4</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-
             <!-- This is the rule that builds the zip file for download. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/jdsol-spec/src/main/asciidoc/jdsol.adoc
+++ b/jdsol-spec/src/main/asciidoc/jdsol.adoc
@@ -469,7 +469,7 @@ on the last line terminates the embedded SMAPs.
 
 === SMAP Syntax
 
-[source,subs=macros]
+[listing,subs="+macros"]
 ----
 SMAP:
             Header { Section } EndSection

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <version>1.0.6</version>
     </parent>
 
-    <groupId>org.eclipse.ee4j.jsp</groupId>
+    <groupId>jakarta.servlet.jsp</groupId>
     <artifactId>jsp-parent</artifactId>
     <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -35,18 +35,6 @@
     <name>Jakarta Server Pages API</name>
     <description>Jakarta Server Pages API</description>
     <url>https://projects.eclipse.org/projects/ee4j.jsp</url>
-    <licenses>
-        <license>
-            <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-        <license>
-            <name>GPL2 w/ CPE</name>
-            <url>https://www.gnu.org/software/classpath/license.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
 
     <modules>
         <module>api</module>
@@ -55,36 +43,4 @@
         <module>impl</module>
     </modules>
 
-    <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/jsp-api.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/jsp-api.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/jsp-api</url>
-        <tag>HEAD</tag>
-    </scm>
-
-    <build>
-        <plugins>
-            <!-- Sets minimal Maven version to 3.5.4 -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M2</version>
-                <executions>
-                    <execution>
-                        <id>enforce-maven</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.5.4</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.6</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <groupId>jakarta.jsp</groupId>
@@ -35,9 +35,57 @@
     <description>Jakarta Server Pages - Specification</description>
     <url>https://projects.eclipse.org/projects/ee4j.jsp</url>
 
+    <licenses>
+        <license>
+            <name>Eclipse Foundation Specification License – v1.0</name>
+            <url>https://www.eclipse.org/legal/efsl.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>jakarta-ee4j-jsp</id>
+            <name>Jakarta Server Pages Developers</name>
+            <organization>Eclipse Foundation</organization>
+            <email>jsp-dev@eclipse.org</email>
+        </developer>
+    </developers>
+
+    <contributors>
+       <contributor>
+           <name>Jakarta Server Pages Contributors</name>
+           <email>jsp-dev@eclipse.org</email>
+           <url>https://github.com/eclipse-ee4j/jsp-api/graphs/contributors</url>
+       </contributor>
+    </contributors>
+
+    <mailingLists>
+        <mailingList>
+            <name>JSP dev mailing list</name>
+            <post>jsp-dev@eclipse.org</post>
+            <subscribe>https://dev.eclipse.org/mailman/listinfo/jsp-dev</subscribe>
+            <unsubscribe>https://dev.eclipse.org/mailman/listinfo/jsp-dev</unsubscribe>
+            <archive>https://dev.eclipse.org/mhonarc/lists/jsp-dev</archive>
+        </mailingList>
+    </mailingLists>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-ee4j/jsp-api.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/eclipse-ee4j/jsp-api.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/jsp-api</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>github</system>
+        <url>https://github.com/eclipse-ee4j/jsp-api/issues</url>
+    </issueManagement>
+
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.2.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jruby.version>9.2.11.1</jruby.version>
@@ -50,6 +98,33 @@
     <build>
         <defaultGoal>package</defaultGoal>
         <plugins>
+            <!-- Sets minimal Maven version to 3.5.4 and Java version to 8 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.4</version>
+                                    <message>You need Maven 3.5.4 or higher</message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>1.8</version>
+                                    <message>You need JDK8 or higher</message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -69,34 +144,11 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
-                <executions>
-                    <execution>
-                        <id>enforce-versions</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireMavenVersion>
-                                    <version>3.5.4</version>
-                                </requireMavenVersion>
-                                <requireJavaVersion>
-                                    <version>[1.8.0,)</version>
-                                    <message>You need JDK8 or higher</message>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>2.0.0-RC.1</version>
+                <version>${asciidoctor.maven.plugin.version}</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>


### PR DESCRIPTION
A small collection of clean-up and fixes

- Fix some Javadoc warnings in the implementation
- Compare the POMs with EL and align them (I did some work on the EL POMs earlier this week)
- Fix cross-references into the syntac block for the PDF output