### PR TITLE
Specify staging profile ID

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -277,6 +277,15 @@ Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Explicitly define staging profile ID as auto-matching finds wrong one -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                  <stagingProfileId>3bda51d9c036</stagingProfileId>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -266,6 +266,15 @@ Use is subject to <a href="http://www.eclipse.org/legal/epl-2.0" target="_top">l
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Explicitly define staging profile ID as auto-matching finds wrong one -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                  <stagingProfileId>1c0c18a0fc339</stagingProfileId>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Need to do it at the module level to simplify CI system. If the profile
ID is specified in the CI system it will apply to all modules and it
only needs to apply to the API. The implementation has a separate
staging profile ID. There are ways around this in the CI system but this
should be simpler.

Signed-off-by: Mark Thomas <markt@apache.org>