### PR TITLE
Add JPMS automatic module name

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -216,6 +216,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>jakarta.servlet.jsp.api</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                     <excludes>
                         <exclude>**/*.java</exclude>


### PR DESCRIPTION
Uses the same naming convention as EL and WebSocket

Signed-off-by: Mark Thomas <markt@apache.org>