### PR TITLE
Replace javax.servlet with jakarta.servlet in HelloServlet

### DIFF
--- a/jdsol-spec/src/main/asciidoc/jdsol.adoc
+++ b/jdsol-spec/src/main/asciidoc/jdsol.adoc
@@ -1089,8 +1089,8 @@ language source file is `HelloServlet.java`:
 
 [cols=">10%,90%"]
 |===
-|1 |`import javax.servlet.*;`
-|2 |`import javax.servlet.http.*;`
+|1 |`import jakarta.servlet.*;`
+|2 |`import jakarta.servlet.http.*;`
 |3 |
 |4 |`public class HelloServlet extends HttpServlet {`
 |5 |`  public void doGet(HttpServletRequest request,`


### PR DESCRIPTION
Signed-off-by: Ivar Grimstad <ivar.grimstad@eclipse-foundation.org>

This is a minor fix for the JDSOL spec. It would be great if it was included in Jakarta EE 9, but I don't think it is a showstopper. Not sure what other spec committee members may think though.