### PR TITLE
Add sentence to Preface for references of JSP in spec doc.

### DIFF
--- a/spec/src/main/asciidoc/ServerPages.adoc
+++ b/spec/src/main/asciidoc/ServerPages.adoc
@@ -25,7 +25,8 @@ Comments to: jsp-dev@eclipse.org
 
 This is the Jakarta Server Pages specification
 version 3.0, developed by the Jakarta Server Pages Team under the Eclipse
-Foundation Specification Process.
+Foundation Specification Process. References in this document to JSP refer
+to Jakarta Server Pages unless otherwise noted.
 
 ==== Who Should Read This Document
 


### PR DESCRIPTION
fixes #184

Using [https://jakarta.ee/legal/acronym_guidelines/](https://jakarta.ee/legal/acronym_guidelines/) as guidance here.

> References in this document to JMS refer to the Jakarta Message Service unless otherwise noted.

I've added:

> References in this document to JSP refer to Jakarta Server Pages unless otherwise noted.

I did not include `the` before `Jakarta Server Pages` as it read better to me, however if you think I should add it in I can do that.

