### PR TITLE
Fixes issue #197 - Add automatic module name for the implementation jar

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -204,6 +204,7 @@
                             <Specification-Vendor>${vendorName}</Specification-Vendor>
                             <Implementation-Version>${project.version}</Implementation-Version>
                             <Implementation-Vendor>${vendorName}</Implementation-Vendor>
+                            <Automatic-Module-Name>jakarta.servlet.jsp.impl</Automatic-Module-Name>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Fixes #197 

As the implementation has two "main" packages (org.apache.jasper and org.glassfish.jsp.api) choosing the automatic module name can be a little hard.

Signed-off-by: Thiago Henrique Hüpner <thihup@gmail.com>