### PR TITLE
Fix #235 Add support for query string in ErrorData

### DIFF
--- a/api/src/main/java/jakarta/servlet/jsp/ErrorData.java
+++ b/api/src/main/java/jakarta/servlet/jsp/ErrorData.java
@@ -28,10 +28,11 @@ package jakarta.servlet.jsp;
  */
 public final class ErrorData {
 
-    private Throwable throwable;
-    private int statusCode;
-    private String uri;
-    private String servletName;
+    private final Throwable throwable;
+    private final int statusCode;
+    private final String uri;
+    private final String queryString;
+    private final String servletName;
 
     /**
      * Creates a new ErrorData object.
@@ -40,12 +41,29 @@ public final class ErrorData {
      * @param statusCode  The status code of the error
      * @param uri         The request URI
      * @param servletName The name of the servlet invoked
+     * 
+     * @deprecated Use {@link ErrorData#ErrorData(Throwable, int, String, String, String)}
      */
+    @Deprecated(since = "4.0", forRemoval = true)
     public ErrorData(Throwable throwable, int statusCode, String uri, String servletName) {
+        this(throwable, statusCode, uri, servletName, null);
+    }
+
+    /**
+     * Creates a new ErrorData object.
+     *
+     * @param throwable   The Throwable that is the cause of the error
+     * @param statusCode  The status code of the error
+     * @param uri         The request URI
+     * @param servletName The name of the servlet invoked
+     * @param queryString The request query string
+     */
+    public ErrorData(Throwable throwable, int statusCode, String uri, String servletName, String queryString) {
         this.throwable = throwable;
         this.statusCode = statusCode;
         this.uri = uri;
         this.servletName = servletName;
+        this.queryString = queryString;
     }
 
     /**
@@ -82,5 +100,15 @@ public final class ErrorData {
      */
     public String getServletName() {
         return this.servletName;
+    }
+
+    /**
+     * Returns the request query string or {@code null} if the request had no
+     * query string.
+     *
+     * @return The request query string
+     */
+    public String getQueryString() {
+        return this.queryString;
     }
 }

--- a/api/src/main/java/jakarta/servlet/jsp/PageContext.java
+++ b/api/src/main/java/jakarta/servlet/jsp/PageContext.java
@@ -424,7 +424,8 @@ abstract public class PageContext extends JspContext {
         return new ErrorData((Throwable) getRequest().getAttribute("jakarta.servlet.error.exception"),
                 ((Integer) getRequest().getAttribute("jakarta.servlet.error.status_code")).intValue(),
                 (String) getRequest().getAttribute("jakarta.servlet.error.request_uri"),
-                (String) getRequest().getAttribute("jakarta.servlet.error.servlet_name"));
+                (String) getRequest().getAttribute("jakarta.servlet.error.servlet_name"),
+                (String) getRequest().getAttribute("jakarta.servlet.error.query_string"));
     }
 
 }

--- a/spec/src/main/asciidoc/ServerPages.adoc
+++ b/spec/src/main/asciidoc/ServerPages.adoc
@@ -11443,6 +11443,10 @@ Jakarta Server Pages specification. This appendix is non-normative.
 
 * Remove the deprecated `jsp:plugin` action and related actions.
 
+* https://github.com/eclipse-ee4j/jsp-api/issues/235[#235]
+  Update `ErrorData` to add support for the new attribute
+  `jakarta.servlet.error.query_string`
+
 === Changes between JSP 3.1 and JSP 3.0
 
 * Deprecate methods that override `ELResolver.getFeatureDescriptors()` as that


### PR DESCRIPTION
Servlet 6.1 adds new attribute jakarta.servlet.error.query_string